### PR TITLE
Implement kinematics hook and tests

### DIFF
--- a/src/features/powerlifting/hooks/useKinematics.js
+++ b/src/features/powerlifting/hooks/useKinematics.js
@@ -1,0 +1,322 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { liftData } from '../lib/liftData.js';
+
+export const TORQUE_FORCE = 1;
+
+const toLimbKey = (from, to) => `${from}->${to}`;
+
+const isValidPoint = (point) =>
+  Boolean(point) && Number.isFinite(point.x) && Number.isFinite(point.y);
+
+export function computeLimbLengths(path, limbs) {
+  const lengths = {};
+
+  limbs.forEach(({ from, to }) => {
+    const fromPoint = path[from];
+    const toPoint = path[to];
+
+    if (!fromPoint || !toPoint) {
+      lengths[toLimbKey(from, to)] = 0;
+      return;
+    }
+
+    const dx = toPoint.x - fromPoint.x;
+    const dy = toPoint.y - fromPoint.y;
+    lengths[toLimbKey(from, to)] = Math.hypot(dx, dy);
+  });
+
+  return lengths;
+}
+
+export function computeDefaultAngles(path, limbs) {
+  const angles = {};
+
+  limbs.forEach(({ from, to }) => {
+    const fromPoint = path[from];
+    const toPoint = path[to];
+
+    if (!fromPoint || !toPoint) {
+      angles[to] = 0;
+      return;
+    }
+
+    const dx = toPoint.x - fromPoint.x;
+    const dy = toPoint.y - fromPoint.y;
+    angles[to] = Math.atan2(dy, dx);
+  });
+
+  return angles;
+}
+
+export function findRootJoints(path, limbs) {
+  const children = new Set(limbs.map(({ to }) => to));
+  return Object.keys(path).filter((joint) => joint !== 'bar' && !children.has(joint));
+}
+
+export function resolveJointPositions({
+  path,
+  limbs,
+  limbLengths,
+  jointAngles,
+  rootJoints,
+}) {
+  const resolved = {};
+
+  rootJoints.forEach((joint) => {
+    if (path[joint]) {
+      resolved[joint] = { ...path[joint] };
+    }
+  });
+
+  const remaining = limbs.map((limb) => ({ ...limb }));
+  let iterations = 0;
+  const maxIterations = limbs.length * 2;
+
+  while (remaining.length && iterations < maxIterations) {
+    const nextIteration = [];
+
+    remaining.forEach((limb) => {
+      const { from, to } = limb;
+      const parent = resolved[from];
+
+      if (!parent) {
+        nextIteration.push(limb);
+        return;
+      }
+
+      const angle = jointAngles[to];
+      const length = limbLengths[toLimbKey(from, to)] ?? 0;
+
+      resolved[to] = {
+        x: parent.x + Math.cos(angle) * length,
+        y: parent.y + Math.sin(angle) * length,
+      };
+    });
+
+    if (nextIteration.length === remaining.length) {
+      break;
+    }
+
+    remaining.splice(0, remaining.length, ...nextIteration);
+    iterations += 1;
+  }
+
+  Object.entries(path).forEach(([joint, coordinates]) => {
+    if (!resolved[joint] && joint !== 'bar') {
+      resolved[joint] = { ...coordinates };
+    }
+  });
+
+  return resolved;
+}
+
+export function buildBarTrajectory(defaultBar, overrides = []) {
+  if (!defaultBar) {
+    return [];
+  }
+
+  const trajectory = [{ ...defaultBar }];
+
+  if (!Array.isArray(overrides)) {
+    return trajectory;
+  }
+
+  overrides.forEach((point) => {
+    if (isValidPoint(point)) {
+      trajectory.push({ x: point.x, y: point.y });
+    }
+  });
+
+  return trajectory;
+}
+
+export function calculateTorqueEstimates({
+  limbs,
+  limbLengths,
+  jointAngles,
+  defaultAngles,
+}) {
+  const torques = {};
+  const gravityAngle = Math.PI / 2;
+
+  limbs.forEach(({ from, to }) => {
+    const length = limbLengths[toLimbKey(from, to)] ?? 0;
+    const angle = jointAngles[to] ?? defaultAngles[to] ?? 0;
+    const leverArm = length * Math.sin(angle - gravityAngle);
+    torques[to] = leverArm * TORQUE_FORCE;
+  });
+
+  return torques;
+}
+
+export function getKinematicsSnapshot(
+  liftType,
+  { jointAngles: overridesAngles = {}, barPath: barOverrides = [] } = {},
+) {
+  const lift = liftData[liftType] ?? liftData.Squat;
+  const { path, limbs } = lift;
+
+  const limbLengths = computeLimbLengths(path, limbs);
+  const defaultAngles = computeDefaultAngles(path, limbs);
+  const rootJoints = findRootJoints(path, limbs);
+
+  const resolvedJointAngles = { ...defaultAngles };
+  Object.entries(overridesAngles || {}).forEach(([joint, value]) => {
+    if (Number.isFinite(value)) {
+      resolvedJointAngles[joint] = value;
+    }
+  });
+
+  const jointCoordinates = resolveJointPositions({
+    path,
+    limbs,
+    limbLengths,
+    jointAngles: resolvedJointAngles,
+    rootJoints,
+  });
+
+  const barTrajectory = buildBarTrajectory(path.bar, barOverrides);
+  const barPosition =
+    barTrajectory.length > 0 ? barTrajectory[barTrajectory.length - 1] : undefined;
+
+  const torqueEstimates = calculateTorqueEstimates({
+    limbs,
+    limbLengths,
+    jointAngles: resolvedJointAngles,
+    defaultAngles,
+  });
+
+  return {
+    limbLengths,
+    defaultAngles,
+    resolvedJointAngles,
+    jointCoordinates,
+    barTrajectory,
+    barPosition,
+    torqueEstimates,
+  };
+}
+
+function computeInitialAdjustments(defaultAngles, jointOverrides = {}) {
+  const adjustments = {};
+
+  Object.entries(jointOverrides).forEach(([joint, value]) => {
+    if (Number.isFinite(value) && defaultAngles[joint] !== undefined) {
+      adjustments[joint] = value - defaultAngles[joint];
+    }
+  });
+
+  return adjustments;
+}
+
+export function useKinematics({ liftType, jointOverrides } = {}) {
+  const activeLiftType = liftType && liftData[liftType] ? liftType : 'Squat';
+
+  const baseSnapshot = useMemo(
+    () => getKinematicsSnapshot(activeLiftType),
+    [activeLiftType],
+  );
+
+  const { defaultAngles } = baseSnapshot;
+
+  const initialAdjustments = useMemo(
+    () => computeInitialAdjustments(defaultAngles, jointOverrides),
+    [defaultAngles, jointOverrides],
+  );
+
+  const [angleAdjustments, setAngleAdjustments] = useState(initialAdjustments);
+  const [barPath, setBarPathState] = useState([]);
+
+  useEffect(() => {
+    setAngleAdjustments(initialAdjustments);
+    setBarPathState([]);
+  }, [initialAdjustments, activeLiftType]);
+
+  const jointAngles = useMemo(() => {
+    const resolved = { ...defaultAngles };
+    Object.entries(angleAdjustments).forEach(([joint, delta]) => {
+      resolved[joint] = defaultAngles[joint] + delta;
+    });
+    return resolved;
+  }, [angleAdjustments, defaultAngles]);
+
+  const snapshot = useMemo(
+    () => getKinematicsSnapshot(activeLiftType, { jointAngles, barPath }),
+    [activeLiftType, jointAngles, barPath],
+  );
+
+  const setJointAngle = useCallback(
+    (joint, angle) => {
+      if (!Number.isFinite(angle)) {
+        return;
+      }
+
+      setAngleAdjustments((prev) => {
+        const base = defaultAngles[joint] ?? 0;
+        const delta = angle - base;
+        if (Math.abs((prev[joint] ?? 0) - delta) < 1e-9) {
+          return prev;
+        }
+        return { ...prev, [joint]: delta };
+      });
+    },
+    [defaultAngles],
+  );
+
+  const adjustJointAngle = useCallback(
+    (joint, delta) => {
+      if (!Number.isFinite(delta)) {
+        return;
+      }
+      setAngleAdjustments((prev) => ({
+        ...prev,
+        [joint]: (prev[joint] ?? 0) + delta,
+      }));
+    },
+    [],
+  );
+
+  const resetJointAngles = useCallback(() => {
+    setAngleAdjustments(initialAdjustments);
+  }, [initialAdjustments]);
+
+  const setBarPath = useCallback((points) => {
+    if (!Array.isArray(points)) {
+      setBarPathState([]);
+      return;
+    }
+
+    const cleaned = points.filter((point) => isValidPoint(point));
+    setBarPathState(cleaned);
+  }, []);
+
+  const appendBarPathPoint = useCallback((point) => {
+    if (!isValidPoint(point)) {
+      return;
+    }
+    setBarPathState((prev) => [...prev, { x: point.x, y: point.y }]);
+  }, []);
+
+  const resetBarPath = useCallback(() => {
+    setBarPathState([]);
+  }, []);
+
+  return {
+    limbLengths: snapshot.limbLengths,
+    defaultAngles: snapshot.defaultAngles,
+    jointAngles,
+    resolvedJointAngles: snapshot.resolvedJointAngles,
+    jointCoordinates: snapshot.jointCoordinates,
+    barTrajectory: snapshot.barTrajectory,
+    barPosition: snapshot.barPosition,
+    torqueEstimates: snapshot.torqueEstimates,
+    setJointAngle,
+    adjustJointAngle,
+    resetJointAngles,
+    setBarPath,
+    appendBarPathPoint,
+    resetBarPath,
+  };
+}
+
+export default useKinematics;

--- a/src/features/powerlifting/hooks/useKinematics.test.js
+++ b/src/features/powerlifting/hooks/useKinematics.test.js
@@ -1,0 +1,160 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { liftData } from '../lib/liftData.js';
+import {
+  TORQUE_FORCE,
+  getKinematicsSnapshot,
+} from './useKinematics.js';
+
+const toLimbKey = (from, to) => `${from}->${to}`;
+
+describe('useKinematics geometry and torque', () => {
+  it('reconstructs squat default geometry and torque values', () => {
+    const snapshot = getKinematicsSnapshot('Squat');
+    const { jointCoordinates, limbLengths, torqueEstimates, defaultAngles } = snapshot;
+    const { path, limbs } = liftData.Squat;
+
+    limbs.forEach(({ from, to }) => {
+      const expectedLength = Math.hypot(
+        path[to].x - path[from].x,
+        path[to].y - path[from].y,
+      );
+      assert.ok(
+        Math.abs(limbLengths[toLimbKey(from, to)] - expectedLength) < 1e-5,
+        'segment length matches default geometry',
+      );
+
+      const parent = jointCoordinates[from];
+      const child = jointCoordinates[to];
+      assert.ok(parent, 'parent joint is defined');
+      assert.ok(child, 'child joint is defined');
+      const actualLength = Math.hypot(child.x - parent.x, child.y - parent.y);
+      assert.ok(Math.abs(actualLength - expectedLength) < 1e-5, 'limb length preserved');
+
+      const expectedTorque =
+        expectedLength * Math.sin(defaultAngles[to] - Math.PI / 2) * TORQUE_FORCE;
+      assert.ok(
+        Math.abs(torqueEstimates[to] - expectedTorque) < 1e-5,
+        'torque matches gravitational estimate',
+      );
+    });
+
+    Object.entries(path).forEach(([joint, coordinates]) => {
+      if (joint === 'bar') return;
+      const { x, y } = jointCoordinates[joint];
+      assert.ok(Math.abs(x - coordinates.x) < 1e-5, 'joint x coordinate matches default');
+      assert.ok(Math.abs(y - coordinates.y) < 1e-5, 'joint y coordinate matches default');
+    });
+  });
+
+  it('updates bench geometry and torque when the elbow angle changes', () => {
+    const baseSnapshot = getKinematicsSnapshot('Bench');
+    const elbowDelta = 0.25;
+    const nextElbowAngle = baseSnapshot.defaultAngles.elbow + elbowDelta;
+
+    const updated = getKinematicsSnapshot('Bench', {
+      jointAngles: { elbow: nextElbowAngle },
+    });
+
+    const shoulder = liftData.Bench.path.shoulder;
+    const upperArmLength = baseSnapshot.limbLengths[toLimbKey('shoulder', 'elbow')];
+    const expectedElbow = {
+      x: shoulder.x + Math.cos(nextElbowAngle) * upperArmLength,
+      y: shoulder.y + Math.sin(nextElbowAngle) * upperArmLength,
+    };
+
+    assert.ok(
+      Math.abs(updated.jointCoordinates.elbow.x - expectedElbow.x) < 1e-5,
+      'elbow x coordinate updates from angle change',
+    );
+    assert.ok(
+      Math.abs(updated.jointCoordinates.elbow.y - expectedElbow.y) < 1e-5,
+      'elbow y coordinate updates from angle change',
+    );
+
+    const forearmLength = baseSnapshot.limbLengths[toLimbKey('elbow', 'grip')];
+    const gripAngle = baseSnapshot.defaultAngles.grip;
+    const expectedGrip = {
+      x: expectedElbow.x + Math.cos(gripAngle) * forearmLength,
+      y: expectedElbow.y + Math.sin(gripAngle) * forearmLength,
+    };
+
+    assert.ok(
+      Math.abs(updated.jointCoordinates.grip.x - expectedGrip.x) < 1e-5,
+      'grip x coordinate follows elbow rotation',
+    );
+    assert.ok(
+      Math.abs(updated.jointCoordinates.grip.y - expectedGrip.y) < 1e-5,
+      'grip y coordinate follows elbow rotation',
+    );
+
+    const expectedTorque =
+      upperArmLength * Math.sin(nextElbowAngle - Math.PI / 2) * TORQUE_FORCE;
+    assert.ok(
+      Math.abs(updated.torqueEstimates.elbow - expectedTorque) < 1e-5,
+      'elbow torque reflects new angle',
+    );
+    assert.ok(
+      Math.abs(updated.torqueEstimates.elbow - baseSnapshot.torqueEstimates.elbow) > 1e-5,
+      'elbow torque differs from baseline after adjustment',
+    );
+  });
+
+  it('resolves deadlift adjustments and bar trajectory changes', () => {
+    const baseSnapshot = getKinematicsSnapshot('Deadlift');
+    const nextKneeAngle = baseSnapshot.defaultAngles.knee - 0.3;
+
+    const barOverride = {
+      x: baseSnapshot.barPosition.x + 12,
+      y: baseSnapshot.barPosition.y - 18,
+    };
+
+    const updated = getKinematicsSnapshot('Deadlift', {
+      jointAngles: { knee: nextKneeAngle },
+      barPath: [barOverride],
+    });
+
+    const hip = liftData.Deadlift.path.hip;
+    const thighLength = baseSnapshot.limbLengths[toLimbKey('hip', 'knee')];
+    const expectedKnee = {
+      x: hip.x + Math.cos(nextKneeAngle) * thighLength,
+      y: hip.y + Math.sin(nextKneeAngle) * thighLength,
+    };
+
+    assert.ok(
+      Math.abs(updated.jointCoordinates.knee.x - expectedKnee.x) < 1e-5,
+      'knee x coordinate updates from adjustment',
+    );
+    assert.ok(
+      Math.abs(updated.jointCoordinates.knee.y - expectedKnee.y) < 1e-5,
+      'knee y coordinate updates from adjustment',
+    );
+
+    const shankLength = baseSnapshot.limbLengths[toLimbKey('knee', 'foot')];
+    const footAngle = baseSnapshot.defaultAngles.foot;
+    const expectedFoot = {
+      x: expectedKnee.x + Math.cos(footAngle) * shankLength,
+      y: expectedKnee.y + Math.sin(footAngle) * shankLength,
+    };
+
+    assert.ok(
+      Math.abs(updated.jointCoordinates.foot.x - expectedFoot.x) < 1e-5,
+      'foot x coordinate follows knee adjustment',
+    );
+    assert.ok(
+      Math.abs(updated.jointCoordinates.foot.y - expectedFoot.y) < 1e-5,
+      'foot y coordinate follows knee adjustment',
+    );
+
+    const expectedTorque =
+      thighLength * Math.sin(nextKneeAngle - Math.PI / 2) * TORQUE_FORCE;
+    assert.ok(
+      Math.abs(updated.torqueEstimates.knee - expectedTorque) < 1e-5,
+      'knee torque reflects adjusted geometry',
+    );
+
+    assert.strictEqual(updated.barTrajectory.length, 2);
+    assert.deepStrictEqual(updated.barTrajectory[0], baseSnapshot.barPosition);
+    assert.deepStrictEqual(updated.barTrajectory[1], barOverride);
+  });
+});


### PR DESCRIPTION
## Summary
- rename the powerlifting hook to useKinematics and seed it with lift data limb lengths and angles
- add helpers and stateful setters to derive joint coordinates, bar trajectory, and torque estimates
- create node:test coverage verifying squat, bench, and deadlift geometry and torque calculations

## Testing
- node --test src/features/powerlifting/hooks/useKinematics.test.js

------
https://chatgpt.com/codex/tasks/task_e_68d795fcd94c832b91be0a51cc3d93b3