### PR TITLE
Improve responsive front-end layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>temp-vite-project</title>
+    <title>Light weight, baby</title>
   </head>
   <body>
     <div id="root"></div>

--- a/src/App.css
+++ b/src/App.css
@@ -1,0 +1,128 @@
+.app-layout {
+  width: min(1400px, 100%);
+  margin-inline: auto;
+  display: grid;
+  gap: clamp(1.75rem, 3vw, 2.5rem);
+}
+
+.app-layout__primary {
+  display: grid;
+  grid-template-columns: minmax(0, 7fr) minmax(0, 5fr);
+  gap: clamp(1.5rem, 3vw, 2.5rem);
+  align-items: stretch;
+  min-height: 0;
+}
+
+.app-layout__window {
+  width: 100%;
+  min-height: clamp(340px, 42vw, 540px);
+}
+
+.app-layout__window--analysis .vintage-window-content,
+.app-layout__window--controls .vintage-window-content {
+  padding: clamp(1.25rem, 2vw, 1.85rem);
+}
+
+.app-layout__window--coach {
+  min-height: clamp(180px, 26vh, 240px);
+}
+
+.coach-cue {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  align-items: center;
+  gap: clamp(0.75rem, 2.5vw, 1.5rem);
+  height: 100%;
+}
+
+.coach-cue__ascii {
+  margin: 0;
+  padding: 0.65rem 0.9rem;
+  font-family: 'IBM Plex Mono', 'SFMono-Regular', monospace;
+  font-size: clamp(0.48rem, 1.7vw, 0.72rem);
+  line-height: 1.1;
+  white-space: pre;
+  border: 3px solid var(--neo-border);
+  border-radius: 20px;
+  background: var(--neo-surface-alt);
+  box-shadow: 6px 6px 0 var(--neo-border);
+  max-width: min(240px, 42vw);
+  overflow-x: auto;
+}
+
+.coach-cue__message {
+  display: flex;
+  align-items: center;
+  width: 100%;
+}
+
+.coach-cue__message .typewriter {
+  font-size: clamp(0.95rem, 2.5vw, 1.2rem);
+  line-height: 1.35;
+}
+
+@media (max-width: 1200px) {
+  .app-layout__primary {
+    grid-template-columns: minmax(0, 1.1fr) minmax(0, 0.9fr);
+  }
+}
+
+@media (max-width: 1024px) {
+  .app-layout__window {
+    min-height: clamp(320px, 55vh, 500px);
+  }
+}
+
+@media (max-width: 900px) {
+  .app-layout__primary {
+    grid-template-columns: 1fr;
+  }
+
+  .app-layout__window {
+    min-height: auto;
+  }
+
+  .app-layout__window--controls {
+    order: 2;
+  }
+
+  .app-layout__window--analysis {
+    order: 1;
+  }
+}
+
+@media (max-width: 720px) {
+  .app-layout {
+    gap: 1.5rem;
+  }
+
+  .app-layout__window--coach {
+    min-height: auto;
+  }
+
+  .coach-cue {
+    grid-template-columns: 1fr;
+    justify-items: center;
+    text-align: center;
+    gap: 1rem;
+  }
+
+  .coach-cue__ascii {
+    max-width: 100%;
+  }
+
+  .coach-cue__message {
+    justify-content: center;
+  }
+}
+
+@media (max-width: 520px) {
+  .coach-cue__ascii {
+    font-size: clamp(0.55rem, 4vw, 0.68rem);
+    padding: 0.55rem 0.8rem;
+  }
+
+  .coach-cue__message .typewriter {
+    font-size: clamp(0.9rem, 4vw, 1.05rem);
+  }
+}

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -7,6 +7,7 @@ import ChartCanvas from './features/powerlifting/components/ChartCanvas';
 import VintageControlPanel from './features/powerlifting/components/VintageControlPanel';
 import { usePowerlifting } from './features/powerlifting/hooks/usePowerlifting';
 import { PARAMETER_DEFINITIONS, DEFAULT_SETUP_PARAMETERS } from './features/powerlifting/lib/setupParameters';
+import './App.css';
 
 const App = () => {
   const [pavelContent, setPavelContent] = useState({ quotes: [], ascii_art: '' });
@@ -42,40 +43,47 @@ const App = () => {
     return quotePool[Math.floor(Math.random() * quotePool.length)];
   }, [selectedLift, pavelContent.quotes]);
 
+  const asciiArt = pavelContent.ascii_art && pavelContent.ascii_art.trim().length > 0
+    ? pavelContent.ascii_art
+    : ` (•_•)
+<)   )╯
+ /   \\`;
 
   return (
     <MainLayout>
-      <div className="flex flex-1 min-h-0 gap-4">
-        <VintageWindow title="Analysis" className="w-3/5 flex flex-col min-h-[420px]">
-          <ChartCanvas title={`${selectedLift} Analysis`} />
-        </VintageWindow>
-        <VintageWindow title="Controls" className="w-2/5 flex flex-col gap-4 min-h-[420px]">
-          <VintageControlPanel
-            lifts={LIFT_OPTIONS}
-            selectedLift={selectedLift}
-            onSelectLift={setSelectedLift}
-            definitions={PARAMETER_DEFINITIONS} // Pass the whole object
-            values={setupParameters} // Pass the whole nested object
-            defaults={DEFAULT_SETUP_PARAMETERS}
-            onSetupParameterChange={controls.handleSetupParameterChange}
-            onResetSetupParameters={controls.handleResetSetupParameters}
-            angles={kinematics.angles}
-            manualOffsets={controls.manualOffsets}
-            onAngleOffsetChange={controls.handleAngleOffsetChange}
-            onResetAngles={controls.handleResetAdjustments}
-            barOffset={controls.manualBarOffset}
-            onBarOffsetChange={controls.handleBarOffsetChange}
-          />
-        </VintageWindow>
-      </div>
-      <VintageWindow title="Coach's Cue" className="h-32 font-mono text-sm flex-none">
-        <div className="flex items-center h-full">
-          <pre className="text-xs leading-none">{pavelContent.ascii_art}</pre>
-          <div className="flex-1 pl-4">
-            <Typewriter text={cue} />
-          </div>
+      <section className="app-layout">
+        <div className="app-layout__primary">
+          <VintageWindow title="Analysis" className="app-layout__window app-layout__window--analysis">
+            <ChartCanvas title={`${selectedLift} Analysis`} />
+          </VintageWindow>
+          <VintageWindow title="Controls" className="app-layout__window app-layout__window--controls">
+            <VintageControlPanel
+              lifts={LIFT_OPTIONS}
+              selectedLift={selectedLift}
+              onSelectLift={setSelectedLift}
+              definitions={PARAMETER_DEFINITIONS} // Pass the whole object
+              values={setupParameters} // Pass the whole nested object
+              defaults={DEFAULT_SETUP_PARAMETERS}
+              onSetupParameterChange={controls.handleSetupParameterChange}
+              onResetSetupParameters={controls.handleResetSetupParameters}
+              angles={kinematics.angles}
+              manualOffsets={controls.manualOffsets}
+              onAngleOffsetChange={controls.handleAngleOffsetChange}
+              onResetAngles={controls.handleResetAdjustments}
+              barOffset={controls.manualBarOffset}
+              onBarOffsetChange={controls.handleBarOffsetChange}
+            />
+          </VintageWindow>
         </div>
-      </VintageWindow>
+        <VintageWindow title="Coach's Cue" className="app-layout__window app-layout__window--coach">
+          <div className="coach-cue">
+            <pre className="coach-cue__ascii">{asciiArt}</pre>
+            <div className="coach-cue__message">
+              <Typewriter text={cue} />
+            </div>
+          </div>
+        </VintageWindow>
+      </section>
     </MainLayout>
   );
 };

--- a/src/components/effects/Typewriter.css
+++ b/src/components/effects/Typewriter.css
@@ -1,10 +1,30 @@
+.typewriter {
+  font-weight: 800;
+  letter-spacing: 0.16em;
+  color: var(--neo-border);
+}
+
 .typewriter::after {
   content: '_';
-  animation: blink 1s step-end infinite;
+  margin-left: 0.35em;
+  display: inline-block;
+  transform: translateY(-0.05em);
+  background: var(--neo-accent);
+  color: var(--neo-border);
+  padding: 0.05em 0.25em 0.1em;
+  border-radius: 6px;
+  border: 2px solid var(--neo-border);
+  box-shadow: 3px 3px 0 var(--neo-border);
+  animation: blink 1s steps(2, start) infinite;
 }
 
 @keyframes blink {
-  50% {
+  0%,
+  49% {
+    opacity: 1;
+  }
+  50%,
+  100% {
     opacity: 0;
   }
 }

--- a/src/components/layout/MainLayout.css
+++ b/src/components/layout/MainLayout.css
@@ -1,34 +1,118 @@
 .main-layout {
   min-height: 100vh;
   width: 100%;
-  padding: 32px 24px;
+  padding-block: clamp(2rem, 5vw, 3.5rem);
+  padding-inline: clamp(1.5rem, 6vw, 4.5rem);
   display: flex;
   flex-direction: column;
-  gap: 20px;
-  background:
-    radial-gradient(circle at 18px 18px, rgba(255, 255, 255, 0.5) 0 2px, transparent 2px),
-    radial-gradient(circle at 52px 46px, rgba(0, 0, 0, 0.08) 0 1.5px, transparent 1.5px),
-    linear-gradient(135deg, #d7d7d7 0%, #c4c4c4 45%, #b0b0b0 100%);
-  background-size: 72px 72px, 72px 72px, auto;
-  background-blend-mode: screen, multiply, normal;
+  align-items: center;
+  gap: clamp(1.75rem, 3vw, 2.5rem);
+  background: var(--neo-background);
 }
 
 .main-layout__header {
+  width: min(1400px, 100%);
+  background: var(--neo-surface-alt);
+  border: 4px solid var(--neo-border);
+  border-radius: 28px;
+  padding: clamp(1.75rem, 4vw, 2.5rem) clamp(1.5rem, 4vw, 3rem);
+  box-shadow: 14px 14px 0 var(--neo-border);
+  display: flex;
+  flex-direction: column;
+  gap: clamp(0.75rem, 1.6vw, 1.25rem);
+  align-items: center;
+  position: relative;
+  overflow: hidden;
   text-align: center;
-  color: #202020;
-  font-family: 'Chicago', 'Geneva', sans-serif;
-  padding: 14px 0;
-  letter-spacing: 0.14em;
-  text-transform: uppercase;
-  background: linear-gradient(180deg, rgba(255, 255, 255, 0.7), rgba(225, 225, 225, 0.8));
-  border: 3px solid #121212;
-  border-radius: 12px;
-  box-shadow:
-    0 0 0 2px rgba(255, 255, 255, 0.6) inset,
-    6px 6px 0 rgba(0, 0, 0, 0.25);
+}
+
+.main-layout__header::after,
+.main-layout__header::before {
+  content: '';
+  position: absolute;
+  border: 4px solid var(--neo-border);
+  background: var(--neo-surface);
+  box-shadow: 8px 8px 0 var(--neo-border);
+  opacity: 0.2;
+}
+
+.main-layout__header::after {
+  width: 150px;
+  height: 150px;
+  border-radius: 36px;
+  top: -60px;
+  right: -40px;
+}
+
+.main-layout__header::before {
+  width: 120px;
+  height: 120px;
+  border-radius: 28px;
+  bottom: -48px;
+  left: -36px;
 }
 
 .main-layout__title {
-  font-size: 26px;
   margin: 0;
+  font-size: clamp(2rem, 4vw, 3rem);
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  font-weight: 800;
+  color: var(--neo-border);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.6em 1.8em;
+  background: var(--neo-surface);
+  border: 4px solid var(--neo-border);
+  border-radius: 999px;
+  box-shadow: 10px 10px 0 var(--neo-border);
+}
+
+.main-layout__subtitle {
+  margin: 0;
+  max-width: 640px;
+  font-size: clamp(0.95rem, 1.2vw, 1.15rem);
+  line-height: 1.4;
+  font-weight: 600;
+  color: var(--neo-border);
+  background: var(--neo-accent-2);
+  border: 3px solid var(--neo-border);
+  border-radius: 22px;
+  padding: 0.75em 1.5em;
+  box-shadow: 8px 8px 0 var(--neo-border);
+}
+
+.main-layout__body {
+  width: min(1400px, 100%);
+  display: flex;
+  flex-direction: column;
+  gap: clamp(1.75rem, 3vw, 2.5rem);
+}
+
+@media (max-width: 720px) {
+  .main-layout {
+    padding-inline: 1.25rem;
+    padding-block: 1.75rem;
+    gap: 1.5rem;
+  }
+
+  .main-layout__header {
+    border-radius: 24px;
+    padding: 1.5rem;
+  }
+
+  .main-layout__body {
+    gap: 1.5rem;
+    width: 100%;
+  }
+
+  .main-layout__title {
+    padding-inline: 1.2em;
+    box-shadow: 8px 8px 0 var(--neo-border);
+  }
+
+  .main-layout__subtitle {
+    box-shadow: 6px 6px 0 var(--neo-border);
+  }
 }

--- a/src/components/layout/MainLayout.jsx
+++ b/src/components/layout/MainLayout.jsx
@@ -6,10 +6,11 @@ const MainLayout = ({ children }) => {
     <div className="main-layout">
       <header className="main-layout__header">
         <h1 className="main-layout__title">
-          <Typewriter text="Light weight, baby!" />
+          <Typewriter text="Light weight, baby" />
         </h1>
+        <p className="main-layout__subtitle">Data-fueled powerlifting analysis with unapologetically bold energy.</p>
       </header>
-      {children}
+      <main className="main-layout__body">{children}</main>
     </div>
   );
 };

--- a/src/components/layout/VintageWindow.css
+++ b/src/components/layout/VintageWindow.css
@@ -1,67 +1,63 @@
 .vintage-window {
-  background: linear-gradient(180deg, #f5f5f5 0%, #e1e1e1 100%);
-  border: 3px solid #101010;
-  border-radius: 18px;
-  box-shadow:
-    0 0 0 2px #fdfdfd inset,
-    8px 8px 0 rgba(0, 0, 0, 0.25);
+  background: var(--neo-surface);
+  border: 4px solid var(--neo-border);
+  border-radius: 32px;
+  box-shadow: 12px 12px 0 var(--neo-border);
   display: flex;
   flex-direction: column;
+  width: 100%;
+  max-width: 100%;
   min-height: 0;
   overflow: hidden;
+  transition: transform 180ms ease, box-shadow 180ms ease;
+}
+
+.vintage-window:hover {
+  transform: translate(-4px, -4px);
+  box-shadow: 16px 16px 0 var(--neo-border);
 }
 
 .vintage-window-title-bar {
-  background:
-    repeating-linear-gradient(
-      -45deg,
-      rgba(255, 255, 255, 0.45),
-      rgba(255, 255, 255, 0.45) 6px,
-      rgba(0, 0, 0, 0.08) 6px,
-      rgba(0, 0, 0, 0.08) 12px
-    ),
-    linear-gradient(180deg, #3d3d3d 0%, #1f1f1f 100%);
-  border-bottom: 3px solid #101010;
-  padding: 6px 18px;
-  font-family: 'Chicago', 'Geneva', sans-serif;
-  font-size: 14px;
-  color: #f7f7f7;
+  background: var(--neo-accent);
+  padding: 16px 28px;
+  border-bottom: 4px solid var(--neo-border);
   display: flex;
   justify-content: center;
   align-items: center;
-  gap: 14px;
-  position: relative;
+}
+
+.vintage-window-title {
+  font-size: 0.95rem;
+  letter-spacing: 0.22em;
   text-transform: uppercase;
-  letter-spacing: 0.18em;
-}
-
-.vintage-window-title-bar::before,
-.vintage-window-title-bar::after {
-  content: '';
-  position: absolute;
-  top: 50%;
-  transform: translateY(-50%);
-  width: 12px;
-  height: 12px;
-  border-radius: 4px;
-  border: 2px solid #101010;
-  background: linear-gradient(180deg, #f7f7f7 0%, #cfcfcf 100%);
-  box-shadow: 2px 2px 0 rgba(0, 0, 0, 0.25);
-}
-
-.vintage-window-title-bar::before {
-  left: 18px;
-}
-
-.vintage-window-title-bar::after {
-  right: 18px;
+  font-weight: 800;
+  color: var(--neo-border);
+  background: var(--neo-surface);
+  border: 3px solid var(--neo-border);
+  border-radius: 999px;
+  padding: 0.5em 1.6em;
+  box-shadow: 6px 6px 0 var(--neo-border);
 }
 
 .vintage-window-content {
-  padding: 16px;
+  padding: clamp(1.25rem, 2vw, 1.75rem);
   flex-grow: 1;
   min-height: 0;
   display: flex;
   flex-direction: column;
-  background: linear-gradient(180deg, rgba(250, 250, 250, 0.95), rgba(228, 228, 228, 0.95));
+  gap: 1rem;
+  background: var(--neo-surface);
+}
+
+@media (max-width: 720px) {
+  .vintage-window {
+    border-radius: 26px;
+    box-shadow: 10px 10px 0 var(--neo-border);
+  }
+
+  .vintage-window-title {
+    font-size: 0.85rem;
+    letter-spacing: 0.18em;
+    box-shadow: 5px 5px 0 var(--neo-border);
+  }
 }

--- a/src/components/layout/VintageWindow.jsx
+++ b/src/components/layout/VintageWindow.jsx
@@ -1,12 +1,14 @@
 import './VintageWindow.css';
 
 const VintageWindow = ({ title, children, className }) => {
+  const windowClasses = ['vintage-window', className].filter(Boolean).join(' ');
+
   return (
-    <div className={`vintage-window ${className}`}>
+    <div className={windowClasses}>
       <div className="vintage-window-title-bar">
-        <span>{title}</span>
+        <span className="vintage-window-title">{title}</span>
       </div>
-      <div className="vintage-window-content bg-mac-dither">
+      <div className="vintage-window-content">
         {children}
       </div>
     </div>

--- a/src/features/powerlifting/components/ChartCanvas.css
+++ b/src/features/powerlifting/components/ChartCanvas.css
@@ -46,3 +46,14 @@
 .mini-chart .recharts-wrapper {
   filter: contrast(1.05) saturate(1.05);
 }
+
+.chart-canvas__loading {
+  width: 100%;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-family: 'IBM Plex Mono', 'SFMono-Regular', monospace;
+  font-size: clamp(0.9rem, 2vw, 1.05rem);
+  color: #202020;
+}

--- a/src/features/powerlifting/components/ChartCanvas.jsx
+++ b/src/features/powerlifting/components/ChartCanvas.jsx
@@ -132,7 +132,11 @@ const ChartCanvas = ({ title }) => {
   }, []);
 
   if (loading) {
-    return <div className="w-full h-full flex items-center justify-center font-mono">Loading Simulation Data...</div>;
+    return (
+      <div className="chart-canvas__loading" aria-live="polite">
+        Loading Simulation Data...
+      </div>
+    );
   }
 
   return (

--- a/src/features/powerlifting/components/Stepper.css
+++ b/src/features/powerlifting/components/Stepper.css
@@ -1,16 +1,13 @@
 .stepper {
   display: flex;
   flex-direction: column;
-  justify-content: space-between;
-  gap: 8px;
-  background: linear-gradient(180deg, rgba(252, 252, 252, 0.9), rgba(220, 220, 220, 0.9));
-  padding: 12px 14px;
-  border: 3px solid #101010;
-  border-radius: 14px;
-  box-shadow:
-    0 0 0 2px rgba(255, 255, 255, 0.7) inset,
-    4px 4px 0 rgba(0, 0, 0, 0.2);
-  min-height: 84px;
+  gap: 12px;
+  background: var(--neo-surface);
+  padding: 16px 18px;
+  border: 3px solid var(--neo-border);
+  border-radius: 22px;
+  box-shadow: 6px 6px 0 var(--neo-border);
+  min-height: 94px;
 }
 
 .stepper-labels {
@@ -21,62 +18,82 @@
 }
 
 .stepper-label {
-  font-size: 11px;
+  font-size: 0.75rem;
   letter-spacing: 0.18em;
   text-transform: uppercase;
+  font-weight: 700;
 }
 
 .stepper-unit {
-  font-size: 10px;
-  padding: 2px 8px;
-  border: 2px solid #101010;
-  border-radius: 12px;
-  background: linear-gradient(180deg, rgba(255, 255, 255, 0.9), rgba(214, 214, 214, 0.9));
+  font-size: 0.65rem;
+  padding: 0.25em 0.75em;
+  border: 2px solid var(--neo-border);
+  border-radius: 999px;
+  background: var(--neo-accent-2);
+  font-weight: 700;
 }
 
 .stepper-controls {
   display: grid;
-  grid-template-columns: 34px 1fr 34px;
+  grid-template-columns: 42px 1fr 42px;
   align-items: center;
-  gap: 8px;
+  gap: 12px;
 }
 
 .stepper-button {
-  width: 34px;
-  height: 34px;
-  border: 3px solid #101010;
-  border-radius: 12px;
-  background: linear-gradient(180deg, #fdfdfd 0%, #d8d8d8 100%);
+  width: 42px;
+  height: 42px;
+  border: 3px solid var(--neo-border);
+  border-radius: 16px;
+  background: var(--neo-accent);
   cursor: pointer;
-  font-size: 18px;
+  font-size: 22px;
   line-height: 1;
   display: flex;
   align-items: center;
   justify-content: center;
-  transition: transform 120ms ease, box-shadow 120ms ease;
-  box-shadow:
-    0 0 0 2px rgba(255, 255, 255, 0.8) inset,
-    3px 3px 0 rgba(0, 0, 0, 0.2);
+  transition: transform 150ms ease, box-shadow 150ms ease, background-color 150ms ease;
+  box-shadow: 6px 6px 0 var(--neo-border);
+  color: var(--neo-border);
 }
 
 .stepper-button:hover {
-  transform: translate(-1px, -1px);
-  box-shadow:
-    0 0 0 2px rgba(255, 255, 255, 0.8) inset,
-    4px 4px 0 rgba(0, 0, 0, 0.24);
+  transform: translate(-2px, -2px);
+  box-shadow: 8px 8px 0 var(--neo-border);
 }
 
 .stepper-button:active {
   transform: translate(1px, 1px);
+  box-shadow: 4px 4px 0 var(--neo-border);
 }
 
 .stepper-value {
-  font-size: 14px;
-  font-weight: bold;
+  font-size: 1rem;
+  font-weight: 800;
   text-align: center;
-  padding: 6px 0;
-  background: linear-gradient(180deg, rgba(255, 255, 255, 0.9), rgba(210, 210, 210, 0.9));
-  border: 2px solid #101010;
-  border-radius: 12px;
+  padding: 0.55em 0;
+  background: var(--neo-surface-alt);
+  border: 3px solid var(--neo-border);
+  border-radius: 18px;
   font-family: 'IBM Plex Mono', 'SFMono-Regular', monospace;
+  box-shadow: 6px 6px 0 var(--neo-border);
+}
+
+@media (max-width: 720px) {
+  .stepper {
+    padding: 14px 16px;
+  }
+
+  .stepper-controls {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 10px;
+  }
+
+  .stepper-button {
+    width: 100%;
+  }
+
+  .stepper-value {
+    font-size: 0.95rem;
+  }
 }

--- a/src/features/powerlifting/components/VintageControlPanel.css
+++ b/src/features/powerlifting/components/VintageControlPanel.css
@@ -2,85 +2,94 @@
   display: flex;
   flex-direction: column;
   height: 100%;
-  font-family: 'Chicago', 'Geneva', sans-serif;
-  color: #202020;
+  color: var(--neo-border);
+  font-family: 'Inter', 'Segoe UI', 'Helvetica Neue', Arial, sans-serif;
 }
 
 .vintage-control-panel__scroll {
   flex: 1;
   overflow-y: auto;
-  padding-right: 6px;
+  padding-right: 8px;
   display: flex;
   flex-direction: column;
-  gap: 16px;
+  gap: 20px;
 }
 
 .panel-group {
-  background:
-    linear-gradient(150deg, rgba(250, 250, 250, 0.95) 0%, rgba(224, 224, 224, 0.95) 100%);
-  border: 3px solid #101010;
-  border-radius: 16px;
-  box-shadow:
-    0 0 0 2px rgba(255, 255, 255, 0.65) inset,
-    6px 6px 0 rgba(0, 0, 0, 0.18);
-  padding: 14px;
+  background: var(--neo-surface);
+  border: 4px solid var(--neo-border);
+  border-radius: 26px;
+  box-shadow: 10px 10px 0 var(--neo-border);
+  padding: 18px 20px 22px;
   display: flex;
   flex-direction: column;
-  gap: 14px;
+  gap: 16px;
+  position: relative;
+}
+
+.panel-group::after {
+  content: '';
+  position: absolute;
+  inset: 14px 18px auto auto;
+  width: 46px;
+  height: 46px;
+  border-radius: 16px;
+  border: 3px solid var(--neo-border);
+  background: var(--neo-accent-2);
+  opacity: 0.25;
 }
 
 .panel-title {
-  font-size: 13px;
-  letter-spacing: 0.18em;
+  font-size: 0.85rem;
+  letter-spacing: 0.16em;
   text-transform: uppercase;
-  text-align: left;
-  border-bottom: 2px dotted rgba(16, 16, 16, 0.45);
-  padding-bottom: 8px;
+  font-weight: 800;
+  align-self: flex-start;
+  background: var(--neo-accent);
+  border: 3px solid var(--neo-border);
+  border-radius: 18px;
+  padding: 0.35em 1.1em;
+  box-shadow: 6px 6px 0 var(--neo-border);
 }
 
 .panel-button-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(108px, 1fr));
-  gap: 10px;
+  grid-template-columns: repeat(auto-fit, minmax(112px, 1fr));
+  gap: 12px;
 }
 
 .panel-button {
   appearance: none;
-  border: 3px solid #101010;
-  background: linear-gradient(180deg, #fdfdfd 0%, #dcdcdc 100%);
-  padding: 8px 12px;
-  font-size: 11px;
-  letter-spacing: 0.2em;
+  border: 3px solid var(--neo-border);
+  background: var(--neo-surface-alt);
+  padding: 0.75em 1.1em;
+  font-size: 0.7rem;
+  font-weight: 700;
+  letter-spacing: 0.14em;
   text-transform: uppercase;
   cursor: pointer;
-  transition: transform 120ms ease, box-shadow 120ms ease;
-  box-shadow:
-    0 0 0 2px rgba(255, 255, 255, 0.8) inset,
-    4px 4px 0 rgba(0, 0, 0, 0.22);
+  transition: transform 150ms ease, box-shadow 150ms ease, background-color 150ms ease;
+  border-radius: 18px;
+  box-shadow: 6px 6px 0 var(--neo-border);
+  color: var(--neo-border);
 }
 
 .panel-button:hover {
-  transform: translate(-1px, -1px);
-  box-shadow:
-    0 0 0 2px rgba(255, 255, 255, 0.8) inset,
-    5px 5px 0 rgba(0, 0, 0, 0.24);
+  transform: translate(-2px, -2px);
+  box-shadow: 8px 8px 0 var(--neo-border);
 }
 
 .panel-button:focus-visible {
-  outline: 2px dashed #101010;
-  outline-offset: 3px;
+  outline: 3px dashed var(--neo-border);
+  outline-offset: 4px;
 }
 
 .panel-button--active {
-  background: linear-gradient(180deg, #1b1b1b 0%, #2e2e2e 100%);
-  color: #f5f5f5;
-  box-shadow:
-    0 0 0 2px rgba(255, 255, 255, 0.2) inset,
-    inset 0 0 0 4px rgba(0, 0, 0, 0.35);
+  background: var(--neo-accent);
 }
 
 .panel-button--ghost {
-  background: linear-gradient(180deg, rgba(255, 255, 255, 0.45), rgba(210, 210, 210, 0.45));
+  background: var(--neo-surface);
 }
 
 .panel-footer {
@@ -91,9 +100,40 @@
 .parameter-grid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(190px, 1fr));
-  gap: 12px;
+  gap: 14px;
 }
 
 .parameter-grid > * {
   width: 100%;
+}
+
+@media (max-width: 900px) {
+  .panel-button-grid {
+    grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  }
+
+  .parameter-grid {
+    grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  }
+}
+
+@media (max-width: 720px) {
+  .vintage-control-panel__scroll {
+    padding-right: 4px;
+  }
+
+  .panel-group {
+    padding: 16px;
+    border-radius: 22px;
+  }
+
+  .panel-button-grid {
+    grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+    gap: 10px;
+  }
+
+  .parameter-grid {
+    grid-template-columns: 1fr;
+    gap: 12px;
+  }
 }

--- a/src/index.css
+++ b/src/index.css
@@ -2,9 +2,16 @@
 
 :root {
   color-scheme: light;
-  font-family: 'Geneva', 'Chicago', 'Monaco', 'IBM Plex Mono', ui-monospace, 'SFMono-Regular', monospace;
-  background-color: #e5e5e5;
-  color: #0c0c0c;
+  --neo-background: #f3f3ff;
+  --neo-border: #0f0f12;
+  --neo-surface: #ffffff;
+  --neo-surface-alt: #ffe8d6;
+  --neo-accent: #ff7849;
+  --neo-accent-2: #9af0dd;
+  --neo-shadow-color: rgba(15, 15, 18, 0.95);
+  font-family: 'Inter', 'Segoe UI', 'Helvetica Neue', Arial, sans-serif;
+  background-color: var(--neo-background);
+  color: var(--neo-border);
   font-synthesis: none;
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
@@ -20,7 +27,7 @@
 body {
   margin: 0;
   min-height: 100vh;
-  background-color: #e5e5e5;
+  background-color: var(--neo-background);
 }
 
 a {
@@ -32,6 +39,6 @@ a {
 }
 
 ::selection {
-  background-color: rgba(12, 12, 12, 0.15);
-  color: #0c0c0c;
+  background-color: rgba(255, 120, 73, 0.45);
+  color: var(--neo-border);
 }


### PR DESCRIPTION
## Summary
- reorganized the main app into a responsive Neubrutalist grid that keeps analysis, controls, and coach cue balanced across screen sizes
- expanded the main layout and window styling so hero and panels use wider viewports while remaining mobile friendly
- tuned control, stepper, and chart loading styles for better small-screen ergonomics and feedback

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dde49897ec832b839886652283eca1