### PR TITLE
Add crest insignia to header banner

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,43 +1,39 @@
 # Project Light-Weight
 
-> "I believe that if you're a good programmer, you can write code in any language. But if you're a great programmer, you'll know when not to."
+> "Discipline is the bridge between ambition and victory, comrade."
 
 ## The Spark
 
-This project started from a simple observation: there are a lot of strong people in the gym, but not all of them are lifting with technique that's both effective and safe. Inspired by the raw power of legends like Ronnie Coleman and the scientific principles of Pavel Tsatsouline, I wanted to build a tool that could offer clear, data-driven feedback on weightlifting form.
-
-The initial idea was to create a simple stick-figure animation. However, it quickly became apparent that accurately modeling biomechanics is a complex challenge. The existing tools and libraries for this are powerful but have a steep learning curve. This led to a pivot: instead of getting bogged down in complex animations, the project will focus on what matters most to a serious lifter—data.
-
-This project is now about building a web-based application that provides scientific feedback on powerlifting technique through clear, easy-to-understand charts and data visualizations.
+The idea for **Project Light-Weight** lit up while watching iron legends trade shouts with gravity. Between the power of Ronnie Coleman and the precision of Pavel Tsatsouline, it became clear that lifters deserve data that matches their grit. Rather than chasing flashy stick-figure animations, this mission focuses on measurable insight—charts, signals, and biomechanical feedback that help every comrade lift smarter and stay resilient.
 
 ## The Vision
 
-**Project Light-Weight** aims to be a web-based, data-driven tool for powerlifting analysis. It will allow users to define and adjust lifting parameters to receive an accurate biomechanical analysis, helping them optimize performance and reduce injury risk. The project is currently in its early stages, focusing on building a solid foundation for the user interface and a mocked backend.
+The application aims to deliver web-based, data-driven analysis for the competition lifts. Users define their key parameters, and the system responds with science-backed feedback that improves performance and reduces risk. For now, the focus is on a polished interface and a mocked backend, but the long march leads toward a full production stack.
 
 ## Development Roadmap
 
-The project is being developed in stages, starting with a UI-focused prototype and gradually building towards a full-fledged cloud application.
+The roadmap is organized into four stages so each comrade knows exactly where the campaign stands.
 
-### Stage 0: UI Prototype & Backend Mock (Current Stage)
+### Stage 0: UI Prototype & Backend Mock (Current)
 
--   **Objective:** Build a high-fidelity UI and a placeholder backend to rapidly iterate on the user experience.
--   **Frontend:** A chart-centric UI with a "System 7" aesthetic.
--   **Backend:** A placeholder API (`/api/v1/simulate/placeholder`) that returns hardcoded, correctly formatted JSON data.
+- **Objective:** Deliver a high-fidelity interface and a placeholder backend for rapid iteration.
+- **Frontend:** Chart-first React experience with a System 7 inspired aesthetic.
+- **Backend:** Mocked endpoint at `/api/v1/simulate/placeholder` returning hardcoded JSON that matches the production contract.
 
-### Stage 1: Synchronous Localhost (The Technical Prototype)
+### Stage 1: Synchronous Localhost (Technical Prototype)
 
--   **Objective:** Validate the core simulation logic with a working end-to-end proof of concept.
--   **Architecture:** React Frontend <--> FastAPI Server (with OpenSim).
+- **Objective:** Validate core simulation logic end-to-end on a single machine.
+- **Architecture:** React frontend talking to a FastAPI service powered by OpenSim.
 
-### Stage 2: Asynchronous Localhost (The MVP)
+### Stage 2: Asynchronous Localhost (MVP)
 
--   **Objective:** Refactor the prototype into a robust, non-blocking application.
--   **Architecture:** Introduce Celery and Redis for asynchronous task handling.
+- **Objective:** Keep the interface responsive while long-running simulations execute.
+- **Architecture:** Introduce Celery and Redis so the API can offload heavy work.
 
-### Stage 3: Full-Fledged Cloud Deployment (Production)
+### Stage 3: Full Cloud Deployment (Production)
 
--   **Objective:** Deploy the application to the cloud for public access.
--   **Architecture:** A fully managed, scalable cloud infrastructure.
+- **Objective:** Bring the stack to the cloud for reliable, public access.
+- **Architecture:** Managed services and automation that scale with the squad.
 
 ## System Architecture
 
@@ -70,14 +66,14 @@ The project is being developed in stages, starting with a UI-focused prototype a
 
 ## Technology Stack
 
--   **Frontend:** React, Tailwind CSS, Chart.js
--   **Backend API:** Python, FastAPI, Pydantic
--   **Simulation Engine:** OpenSim Python API
--   **Asynchronous Tasks:** Celery
--   **Message Broker & Cache:** Redis
--   **Database:** SQLite (local), PostgreSQL (production)
--   **DevOps:** Docker, Docker Compose, GitHub Actions
+- **Frontend:** React, Tailwind CSS, Chart.js
+- **Backend API:** Python, FastAPI, Pydantic
+- **Simulation Engine:** OpenSim Python API
+- **Asynchronous Tasks:** Celery
+- **Message Broker & Cache:** Redis
+- **Database:** SQLite for local work, PostgreSQL in production
+- **DevOps:** Docker, Docker Compose, GitHub Actions
 
 ## A Note on the Journey
 
-This project is as much about the process as it is about the final product. It's an exploration of how to build a complex application from the ground up, learning and adapting along the way. The journey is documented in the `diary.md` file, which offers a more personal, human-oriented perspective on the project's development.
+This effort is about forging strength together. Every iteration sharpens the tools, every chart tells a story, and every comrade benefits from the shared discipline. The evolving narrative lives in `diary.md`, where decisions, pivots, and reflections are recorded for any teammate or model to study. Light weight, comrade!

--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Light weight, baby</title>
+    <title>Light weight, comrade!</title>
   </head>
   <body>
     <div id="root"></div>

--- a/src/components/layout/MainLayout.css
+++ b/src/components/layout/MainLayout.css
@@ -26,6 +26,57 @@
   text-align: center;
 }
 
+.main-layout__crest {
+  display: inline-flex;
+  align-items: center;
+  gap: clamp(1rem, 2vw, 1.5rem);
+  padding: clamp(0.65rem, 1vw, 0.85rem) clamp(1rem, 2vw, 1.75rem);
+  background: var(--neo-surface);
+  border: 3px solid var(--neo-border);
+  border-radius: 999px;
+  box-shadow: 10px 10px 0 var(--neo-border);
+  transition: transform 200ms ease;
+}
+
+.main-layout__crest:hover {
+  transform: translateY(-2px);
+}
+
+.main-layout__crest-icon {
+  width: clamp(70px, 12vw, 96px);
+  height: clamp(70px, 12vw, 96px);
+  flex: none;
+}
+
+.banner-insignia {
+  display: block;
+  width: 100%;
+  height: 100%;
+}
+
+.main-layout__crest-copy {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  text-align: left;
+  color: var(--neo-border);
+}
+
+.main-layout__crest-title {
+  font-size: clamp(0.85rem, 1vw, 1rem);
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  font-weight: 800;
+}
+
+.main-layout__crest-subtitle {
+  font-size: clamp(0.75rem, 0.9vw, 0.9rem);
+  font-weight: 600;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  opacity: 0.85;
+}
+
 .main-layout__header::after,
 .main-layout__header::before {
   content: '';
@@ -100,6 +151,18 @@
   .main-layout__header {
     border-radius: 24px;
     padding: 1.5rem;
+  }
+
+  .main-layout__crest {
+    flex-direction: column;
+    border-radius: 24px;
+    box-shadow: 8px 8px 0 var(--neo-border);
+    padding: 1rem;
+  }
+
+  .main-layout__crest-copy {
+    text-align: center;
+    gap: 0.25rem;
   }
 
   .main-layout__body {

--- a/src/components/layout/MainLayout.jsx
+++ b/src/components/layout/MainLayout.jsx
@@ -1,12 +1,20 @@
 import Typewriter from '../effects/Typewriter';
+import BannerInsignia from '../visual/BannerInsignia';
 import './MainLayout.css';
 
 const MainLayout = ({ children }) => {
   return (
     <div className="main-layout">
       <header className="main-layout__header">
+        <div className="main-layout__crest" aria-label="Project Light-Weight insignia">
+          <BannerInsignia className="main-layout__crest-icon" />
+          <div className="main-layout__crest-copy">
+            <span className="main-layout__crest-title">Collective of Iron Analytics</span>
+            <span className="main-layout__crest-subtitle">Data. Discipline. Solidarity.</span>
+          </div>
+        </div>
         <h1 className="main-layout__title">
-          <Typewriter text="Light weight, baby" />
+          <Typewriter text="Light weight, comrade!" />
         </h1>
         <p className="main-layout__subtitle">Data-fueled powerlifting analysis with unapologetically bold energy.</p>
       </header>

--- a/src/components/visual/BannerInsignia.jsx
+++ b/src/components/visual/BannerInsignia.jsx
@@ -1,0 +1,44 @@
+const BannerInsignia = ({ className = '' }) => {
+  const classes = ['banner-insignia', className].filter(Boolean).join(' ');
+
+  return (
+    <svg
+      className={classes}
+      viewBox="0 0 120 120"
+      role="img"
+      aria-labelledby="bannerInsigniaTitle bannerInsigniaDesc"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <title id="bannerInsigniaTitle">Project Light-Weight crest</title>
+      <desc id="bannerInsigniaDesc">
+        Circular crest featuring a barbell, laurel wreath, and compass star to symbolize collective strength and precise data.
+      </desc>
+      <defs>
+        <linearGradient id="insigniaGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+          <stop offset="0%" stopColor="var(--neo-accent-2)" />
+          <stop offset="100%" stopColor="var(--neo-accent-1)" />
+        </linearGradient>
+      </defs>
+      <circle cx="60" cy="60" r="56" fill="var(--neo-surface)" stroke="var(--neo-border)" strokeWidth="6" />
+      <circle cx="60" cy="60" r="40" fill="url(#insigniaGradient)" stroke="var(--neo-border)" strokeWidth="4" />
+      <g stroke="var(--neo-border)" strokeWidth="4" strokeLinecap="round" strokeLinejoin="round" fill="none">
+        <path d="M32 60h56" />
+        <path d="M41 50v20" />
+        <path d="M79 50v20" />
+        <circle cx="60" cy="60" r="8" />
+      </g>
+      <g fill="var(--neo-border)">
+        <path d="M60 20l5 12h-10z" />
+        <path d="M60 100l-5-12h10z" />
+        <path d="M20 60l12 5v-10z" />
+        <path d="M100 60l-12-5v10z" />
+      </g>
+      <g stroke="var(--neo-border)" strokeWidth="2" strokeLinecap="round">
+        <path d="M46 30c-10 7-16 18-16 30" />
+        <path d="M74 30c10 7 16 18 16 30" />
+      </g>
+    </svg>
+  );
+};
+
+export default BannerInsignia;


### PR DESCRIPTION
## Summary
- retune the README with a comrade-forward narrative while preserving technical guidance
- replace every "Light weight, baby" reference with "Light weight, comrade!"
- add a modular crest insignia component to the main banner for easy swapping

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68de4dbda98c832ba026ac15e989a658