### PR TITLE
feat: add CLI helper for COE dataset

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,19 @@ The roadmap is organized into four stages so each comrade knows exactly where th
 - **Database:** SQLite for local work, PostgreSQL in production
 - **DevOps:** Docker, Docker Compose, GitHub Actions
 
+## Working with external data
+
+The project now bundles a small CLI helper to explore the Certificate of Entitlement (COE) dataset hosted on [data.gov.sg](https://data.gov.sg). This is useful during development to verify that upstream data is reachable from your environment.
+
+- `npm run fetch:coe` &mdash; fetches a small sample of rows.
+- `npm start -- --fetch-coe` &mdash; tests the API and then (optionally) continue with any additional flags. Combine with:
+  - `--limit <n>` / `--offset <n>` &mdash; pagination controls.
+  - `--month <YYYY-MM>` &mdash; filter for a specific bidding month.
+  - `--category <A|B|C|D|E>` &mdash; focus on a COE category.
+  - `--dev` &mdash; start the Vite dev server after the fetch completes.
+
+You can also expose more verbose logging by setting `DEBUG_DATAGOV=1` before running the command.
+
 ## A Note on the Journey
 
 This effort is about forging strength together. Every iteration sharpens the tools, every chart tells a story, and every comrade benefits from the shared discipline. The evolving narrative lives in `diary.md`, where decisions, pivots, and reflections are recorded for any teammate or model to study. Light weight, comrade!

--- a/package.json
+++ b/package.json
@@ -4,6 +4,8 @@
   "version": "0.0.0",
   "type": "module",
   "scripts": {
+    "start": "node scripts/start.js",
+    "fetch:coe": "node scripts/fetch-coe-data.js",
     "dev": "vite",
     "build": "vite build",
     "lint": "eslint .",

--- a/scripts/fetch-coe-data.js
+++ b/scripts/fetch-coe-data.js
@@ -1,0 +1,118 @@
+#!/usr/bin/env node
+import process from 'node:process';
+
+const DATA_GOV_BASE = 'https://data.gov.sg/api';
+const DATASET_ID = 'd_69b3380ad7e51aff3a7dcc84eba52b8a';
+
+function logDebug(message) {
+  if (process.env.DEBUG_DATAGOV === '1') {
+    console.debug(`[data.gov.sg] ${message}`);
+  }
+}
+
+async function getDatasetMetadata(fetchImpl = fetch) {
+  const response = await fetchImpl(`${DATA_GOV_BASE}/action/package_show?id=${DATASET_ID}`);
+  if (!response.ok) {
+    throw new Error(`Failed to load dataset metadata: ${response.status} ${response.statusText}`);
+  }
+
+  const payload = await response.json();
+  if (!payload.success) {
+    throw new Error('Dataset metadata request did not succeed.');
+  }
+
+  return payload.result;
+}
+
+function selectResource(metadata) {
+  if (!metadata?.resources?.length) {
+    throw new Error('Dataset does not expose any downloadable resources.');
+  }
+
+  const preferred = metadata.resources.find((resource) => resource.datastore_active);
+  if (preferred) {
+    return preferred;
+  }
+
+  // Fallback to the first CSV-like resource if datastore_active is false.
+  const csvLike = metadata.resources.find((resource) => {
+    const format = resource.format?.toLowerCase();
+    return format === 'csv' || format === 'json';
+  });
+
+  if (!csvLike) {
+    throw new Error('Unable to locate a datastore-backed resource for the COE dataset.');
+  }
+
+  return csvLike;
+}
+
+function encodeFilters(filters) {
+  if (!filters || Object.keys(filters).length === 0) {
+    return '';
+  }
+
+  return `&filters=${encodeURIComponent(JSON.stringify(filters))}`;
+}
+
+export async function fetchCoeData({ limit = 20, offset = 0, filters } = {}, fetchImpl = fetch) {
+  if (limit <= 0) {
+    throw new Error('`limit` must be greater than 0.');
+  }
+
+  if (offset < 0) {
+    throw new Error('`offset` cannot be negative.');
+  }
+
+  logDebug(`Fetching dataset metadata for ${DATASET_ID}`);
+  const metadata = await getDatasetMetadata(fetchImpl);
+  const resource = selectResource(metadata);
+  const resourceId = resource.id;
+
+  logDebug(`Using resource ${resourceId}`);
+  const url = `${DATA_GOV_BASE}/action/datastore_search?resource_id=${resourceId}&limit=${limit}&offset=${offset}${encodeFilters(filters)}`;
+  logDebug(`Requesting ${url}`);
+
+  const response = await fetchImpl(url);
+  if (!response.ok) {
+    throw new Error(`Failed to retrieve COE data: ${response.status} ${response.statusText}`);
+  }
+
+  const payload = await response.json();
+  if (!payload.success) {
+    throw new Error('COE data request did not succeed.');
+  }
+
+  const { records = [], total = 0, fields = [] } = payload.result ?? {};
+  return {
+    datasetId: DATASET_ID,
+    resourceId,
+    records,
+    total,
+    fields,
+  };
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  const limitArgIndex = process.argv.indexOf('--limit');
+  const offsetArgIndex = process.argv.indexOf('--offset');
+  const limit = limitArgIndex > -1 ? Number.parseInt(process.argv[limitArgIndex + 1] ?? '', 10) : 5;
+  const offset = offsetArgIndex > -1 ? Number.parseInt(process.argv[offsetArgIndex + 1] ?? '', 10) : 0;
+
+  fetchCoeData({ limit, offset })
+    .then((result) => {
+      console.log(JSON.stringify({
+        datasetId: result.datasetId,
+        resourceId: result.resourceId,
+        total: result.total,
+        sample: result.records,
+      }, null, 2));
+    })
+    .catch((error) => {
+      console.error('Failed to fetch COE data:', error.message);
+      if (process.env.DEBUG_DATAGOV === '1') {
+        console.error(error);
+      }
+      process.exitCode = 1;
+    });
+}

--- a/scripts/start.js
+++ b/scripts/start.js
@@ -1,0 +1,85 @@
+#!/usr/bin/env node
+import { spawn } from 'node:child_process';
+import process from 'node:process';
+import { fetchCoeData } from './fetch-coe-data.js';
+
+const args = process.argv.slice(2);
+const hasFlag = (flag) => args.includes(flag);
+
+const shouldFetchCoe = hasFlag('--fetch-coe') || hasFlag('--test-api');
+const shouldStartDev = (!shouldFetchCoe && args.length === 0) || hasFlag('--dev');
+
+const getNumericArg = (flag, fallback) => {
+  const index = args.indexOf(flag);
+  if (index === -1) {
+    return fallback;
+  }
+
+  const value = Number.parseInt(args[index + 1] ?? '', 10);
+  return Number.isNaN(value) ? fallback : value;
+};
+
+const getStringArg = (flag) => {
+  const index = args.indexOf(flag);
+  if (index === -1) {
+    return undefined;
+  }
+
+  return args[index + 1];
+};
+
+async function run() {
+  if (shouldFetchCoe) {
+    const limit = getNumericArg('--limit', 5);
+    const offset = getNumericArg('--offset', 0);
+    const month = getStringArg('--month');
+    const category = getStringArg('--category');
+
+    const filters = {};
+    if (month) {
+      filters.month = month;
+    }
+    if (category) {
+      filters.category = category;
+    }
+
+    console.log('Fetching COE data from data.gov.sg...');
+    try {
+      const result = await fetchCoeData({
+        limit,
+        offset,
+        filters: Object.keys(filters).length ? filters : undefined,
+      });
+
+      console.log(`Dataset: ${result.datasetId}`);
+      console.log(`Resource: ${result.resourceId}`);
+      console.log(`Records returned: ${result.records.length} of ${result.total}`);
+      console.table(result.records);
+    } catch (error) {
+      console.error('Failed to fetch COE data:', error.message);
+      if (process.env.DEBUG_DATAGOV === '1') {
+        console.error(error);
+      }
+      process.exitCode = 1;
+    }
+  }
+
+  if (shouldStartDev) {
+    const child = spawn('npm', ['run', 'dev'], {
+      stdio: 'inherit',
+      shell: process.platform === 'win32',
+    });
+
+    child.on('exit', (code, signal) => {
+      if (signal) {
+        process.kill(process.pid, signal);
+      } else {
+        process.exitCode = code ?? 0;
+      }
+    });
+  } else if (!shouldFetchCoe) {
+    console.log('Nothing to do. Pass --dev to start the Vite dev server or --fetch-coe to test the API.');
+  }
+}
+
+run();


### PR DESCRIPTION
## Summary
- add a reusable helper to retrieve COE bidding data from data.gov.sg
- expose new npm scripts so `npm start` can optionally fetch COE data before starting the dev server
- document the new workflow for probing the upstream dataset during development

## Testing
- npm run lint *(fails: existing lint errors in powerlifting components)*
- npm start -- --fetch-coe --limit 1 *(fails: network access to data.gov.sg is blocked in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68e907f26644832ba51f00f44f6434a4